### PR TITLE
Add new options to the checksum checker drush cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ Also, since the results of the verification are recorded in each object's audit 
 
 In addition, each time a datastream's checksum is verified, about twice as much data is written to your fedora.log as is stored in the object's audit log, so a more realistic estimate of how much disk space is consumed by routine checksum verification is three times the figures calculated above.
 
+Checksum Checker provides two optional drush options that will calculate the number of objects to check per cron run. They are:  
+* `--days-to-complete`: The number of days it should take to verify the checksums of all objects.
+* `--cmd-run-frequency`: The number of hours between checksum runs (required if --days-to-complete is set). Note that this value (1 for each hour, 2 for every 2 hours, etc.) should correspond to the frequency configured in your server's crontab for running the drush command.
+
+Using these two values, and the number of objects in your repository (which you do not need to provide), Checksum Checker will calculate the number of objects to check each cron run.
+
 ## Documentation
 
 Further documentation for this module is available at [our wiki](https://wiki.duraspace.org/display/ISLANDORA/Islandora+Checksum+Checker).

--- a/islandora_checksum_checker.drush.inc
+++ b/islandora_checksum_checker.drush.inc
@@ -32,7 +32,10 @@
 function islandora_checksum_checker_drush_help($command) {
   switch ($command) {
     case 'drush:run-islandora-checksum-queue':
-      return dt('Populate and process items in the Islandora checksum validation queue.');
+      return dt('Populate and process items in the Islandora checksum validation queue. ' .
+        'Processes the number of items specified in the module admin page, unless the ' .
+        'days-to-complete and cmd-run-frequency optional parameters are passed in. If the optional ' .
+        'parameters are passed in then the command will attempt to process the correct number of items.');
   }
 }
 
@@ -46,25 +49,75 @@ function islandora_checksum_checker_drush_command() {
     'examples' => array(
       'Standard example' => 'drush --user=fedoraAdmin run-islandora-checksum-queue',
       'Alias example' => 'drush --user=fedoraAdmin ricq',
+      'Options example' => 'drush --user=fedoraAdmin --days-to-complete=180 --cmd-run-frequency=12 run-islandora-checksum-queue',
     ),
     'aliases' => array('ricq'),
     'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_LOGIN,
+    'options' => array(
+      'days-to-complete' => array(
+        'description' => 'The number of days it should take to check all the checksums.',
+        'example-value' => 365,
+        'value' => required,
+      ),
+      'cmd-run-frequency' => array(
+        'description' => 'The number of hours between checksum runs (required if --days-to-complete is set).',
+        'example-value' => 12,
+        'value' => required,
+      ),
+    ),
   );
   return $items;
+}
+
+/**
+ * Validation function for drush run-islandora-checksum-queue.
+ */
+function drush_islandora_checksum_checker_run_islandora_checksum_queue_validate() {
+  if (variable_get('islandora_checksum_checker_queue_cron_method', 'drupal') != 'drush') {
+    return drush_set_error('CHECKSUM_CHECKER_NOT_ENABLED', dt('Please enable the drush method in the module config.'));
+  }
+
+  $days = drush_get_option('days-to-complete');
+  $hours = drush_get_option('cmd-run-frequency');
+
+  if ($days != NULL && (!is_numeric($days) || intval($days) != $days || $days <= 0)) {
+    return drush_set_error('CHECKSUM_CHECKER_DAYS', dt('The option --days-to-complete must be a positive integer.'));
+  }
+
+  if ($hours != NULL && (!is_numeric($hours) || intval($hours) != $hours || $hours <= 0)) {
+    return drush_set_error('CHECKSUM_CHECKER_DAYS', dt('The option --cmd-run-frequency must be a positive integer.'));
+  }
+
+  if ($hours == NULL XOR $days == NULL) {
+    return drush_set_error('CHECKSUM_CHECKER_OPTIONS', dt('Both --days-to-complete and --cmd-run-frequency must be specified, or neither specified.'));
+  }
 }
 
 /**
  * Callback function for drush run-islandora-checksum-queue.
  */
 function drush_islandora_checksum_checker_run_islandora_checksum_queue() {
-  if (variable_get('islandora_checksum_checker_queue_cron_method', 'drupal') != 'drush') {
-    return;
-  }
+  $days = drush_get_option('days-to-complete');
+  $hours = drush_get_option('cmd-run-frequency');
+  $time_based_items = $days AND $hours;
 
   // Populate the queue with the next $objects_to_check object PIDs.
   $queue = DrupalQueue::get('validateIslandoraChecksums');
   $items_still_in_queue = $queue->numberOfItems();
-  $objects_to_check = islandora_checksum_checker_get_objects($items_still_in_queue);
+
+  if ($time_based_items) {
+    $repository_items = islandora_checksum_checker_get_number_objects();
+    $limit = ceil(($repository_items / $days) * ($hours / 24));
+  }
+  else {
+    $limit = variable_get('islandora_checksum_checker_items_per_cron', '50');
+    if ($limit > $items_still_in_queue) {
+      $limit = (int) $limit - (int) $items_still_in_queue;
+    }
+  }
+
+  $objects_to_check = islandora_checksum_checker_get_objects($limit);
+
   foreach ($objects_to_check as $object) {
     $queue->createItem($object);
   }

--- a/islandora_checksum_checker.module
+++ b/islandora_checksum_checker.module
@@ -13,7 +13,16 @@ function islandora_checksum_checker_cron() {
     // Populate the queue with the next $objects_to_check object PIDs.
     $queue = DrupalQueue::get('validateIslandoraChecksums');
     $items_still_in_queue = $queue->numberOfItems();
-    $objects_to_check = islandora_checksum_checker_get_objects($items_still_in_queue);
+    $limit = variable_get('islandora_checksum_checker_items_per_cron', '50');
+
+    // Adjust $limit for items left in queue. If $items_still_in_queue
+    // is greater than or equal to $limit, use the configured value for $limit.
+    if ($limit > $items_still_in_queue) {
+      $limit = (int) $limit - (int) $items_still_in_queue;
+    }
+
+    $objects_to_check = islandora_checksum_checker_get_objects($limit);
+
     foreach ($objects_to_check as $object) {
       $queue->createItem($object);
     }
@@ -285,21 +294,13 @@ function islandora_checksum_checker_validate_checksum($pid) {
  * system variable 'islandora_checksum_checker_last_item_checked' to page
  * through all the objects in the repo.
  *
- * @param string $items_still_in_queue
- *   The number of items left in the queue from last cron run (due to
- *   releaseItem(), etc.).
+ * @param int $limit
+ *   The number of items to add to the queue.
  *
  * @return array
  *   An array of PIDs.
  */
-function islandora_checksum_checker_get_objects($items_still_in_queue) {
-  // Set up the limit and offset for the RI query.
-  $limit = variable_get('islandora_checksum_checker_items_per_cron', '50');
-  // Adjust $limit to account for items left in queue. If $items_still_in_queue
-  // is greater than or equal to $limit, use the configured value for $limit.
-  if ($limit > $items_still_in_queue) {
-    $limit = (int) $limit - (int) $items_still_in_queue;
-  }
+function islandora_checksum_checker_get_objects($limit) {
   $offset = variable_get('islandora_checksum_checker_last_item_checked', '0');
   // We need to add 1 to the offset so we can use it in the RI query, except
   // the first time this function is invoked
@@ -357,6 +358,37 @@ EOQ;
   variable_set('islandora_checksum_checker_last_item_checked', $offset);
 
   return $objects_to_check;
+}
+
+/**
+ * Query the RI index for a count.
+ *
+ * Gets the number of items that the checksum checker will run against.
+ *
+ * @return int
+ *   Count of pids.
+ */
+function islandora_checksum_checker_get_number_objects() {
+  $user = user_load(1);
+  drupal_static_reset('islandora_get_tuque_connection');
+  $tuque = islandora_get_tuque_connection($user);
+
+  // Query the rindex to get all the objects that have a 'isMemberOfCollection'
+  // relationship but that do not have a 'islandora:collectionCModel' content
+  // model. Sort oldest to newest.
+  $ri_query = <<<EOQ
+SELECT ?object ?created
+FROM <#ri>
+WHERE {
+  ?object <fedora-model:createdDate> ?created .
+  OPTIONAL {
+    ?object <fedora-model:hasModel> <info:fedora/islandora:collectionCModel> ;
+            <fedora-view:lastModifiedDate> ?probe
+  }
+  FILTER(!bound(?probe))
+}
+EOQ;
+  return $tuque->repository->ri->countQuery($ri_query, 'sparql');
 }
 
 /**


### PR DESCRIPTION
**JIRA Ticket**: (link)
https://jira.duraspace.org/browse/ISLANDORA-1915

# What does this Pull Request do?

This pull request attempts to help answer the question: how many checksums should the checksum checker check when the checksum checker is checking checksums.

The checksum checker options ask the user to specify the number of items per invocation of the batch process. This is difficult to estimate if your repository is continually changing in size. Because generally you want to check all your checksums in a certain amount of time.

This pull request adds extra optional arguements to the checksum checker drush command that let the checksum checker determine the limit based on the number of items in your repository and how long you want it to take to check all your checksums.

# What's new?

This pull request adds two optional arguments to the drush command for the checksum checker. If both of these arguments are specified then the drush command will calculate the number of items that it processes per iteration in order to meet its time target based on the size of the repository. 

If these two arguments are not given then everything should work as it did before.

# How should this be tested?

Run the checksum checker as before with drush and no arguments. Make sure that it functions as it did before. Run the checksum checker with new arguments specified, ensure that the correct number of objects are processed based on the data passed in the arguments.

# Interested parties
@mjordan @DiegoPino