### PR TITLE
ISLANDORA-1931: Changes non existing constant for a string

### DIFF
--- a/islandora_checksum_checker.drush.inc
+++ b/islandora_checksum_checker.drush.inc
@@ -57,12 +57,12 @@ function islandora_checksum_checker_drush_command() {
       'days-to-complete' => array(
         'description' => 'The number of days it should take to check all the checksums.',
         'example-value' => 365,
-        'value' => required,
+        'value' => 'required',
       ),
       'cmd-run-frequency' => array(
         'description' => 'The number of hours between checksum runs (required if --days-to-complete is set).',
         'example-value' => 12,
-        'value' => required,
+        'value' => 'required',
       ),
     ),
   );


### PR DESCRIPTION
https://jira.duraspace.org/browse/ISLANDORA-1931

# What does this Pull Request do?

Changes a constant for a string literal. 

# What's new?
Drush should not give any warnings anymore while enabling or using this module (via drush)

# How should this be tested?

Download and enable the module. No warning should appear.
Run 'drush --user=1  --cmd-run-frequency=12 run-islandora-checksum-queue --days-to-complete' note the lack of `=somenumber` after --days-to-complete. Drush should complain about a missing required value for that one. I say "should" because drush can be deceiving.

Could this change impact execution of existing code? No.

# Interested parties
@Islandora/7-x-1-x-committers @mjordan who offered some time to test.