### PR TITLE
Queuing improvements

### DIFF
--- a/islandora_checksum_checker.drush.inc
+++ b/islandora_checksum_checker.drush.inc
@@ -102,7 +102,7 @@ function drush_islandora_checksum_checker_run_islandora_checksum_queue() {
   $time_based_items = $days AND $hours;
 
   // Populate the queue with the next $objects_to_check object PIDs.
-  $queue = DrupalQueue::get('validateIslandoraChecksums');
+  $queue = DrupalQueue::get('validateIslandoraChecksums', TRUE);
   $items_still_in_queue = $queue->numberOfItems();
 
   if ($time_based_items) {

--- a/islandora_checksum_checker.module
+++ b/islandora_checksum_checker.module
@@ -128,10 +128,17 @@ function islandora_checksum_checker_admin_settings() {
  * Implements hook_cron_queue_info().
  */
 function islandora_checksum_checker_cron_queue_info() {
+  // Only process the queue via cron if the module is configured to do so.
+  $cron_method = variable_get(
+    'islandora_checksum_checker_queue_cron_method',
+    'drupal'
+  );
+
   $queues = array();
   $queues['validateIslandoraChecksums'] = array(
     'worker callback' => 'islandora_checksum_checker_process_queue_item',
     'time' => 60,
+    'skip on cron' => $cron_method != 'drupal',
   );
   return $queues;
 }

--- a/islandora_checksum_checker.module
+++ b/islandora_checksum_checker.module
@@ -134,6 +134,10 @@ function islandora_checksum_checker_cron_queue_info() {
     'drupal'
   );
 
+  // Get the queue first here to ensure DrupalQueue::get() saves a reliable
+  // queue to its static cache.
+  $queue = DrupalQueue::get('validateIslandoraChecksums', TRUE);
+
   $queues = array();
   $queues['validateIslandoraChecksums'] = array(
     'worker callback' => 'islandora_checksum_checker_process_queue_item',

--- a/islandora_checksum_checker.module
+++ b/islandora_checksum_checker.module
@@ -11,7 +11,7 @@
 function islandora_checksum_checker_cron() {
   if (variable_get('islandora_checksum_checker_queue_cron_method', 'drupal') == 'drupal') {
     // Populate the queue with the next $objects_to_check object PIDs.
-    $queue = DrupalQueue::get('validateIslandoraChecksums');
+    $queue = DrupalQueue::get('validateIslandoraChecksums', TRUE);
     $items_still_in_queue = $queue->numberOfItems();
     $limit = variable_get('islandora_checksum_checker_items_per_cron', '50');
 
@@ -147,7 +147,7 @@ function islandora_checksum_checker_cron_queue_info() {
  * Queue worker callback. Processes one queue item.
  */
 function islandora_checksum_checker_process_queue_item() {
-  $queue = DrupalQueue::get('validateIslandoraChecksums');
+  $queue = DrupalQueue::get('validateIslandoraChecksums', TRUE);
   // Get the next queue item.
   while ($item = $queue->claimItem()) {
     // $item->data will be an Islandora object's PID.


### PR DESCRIPTION
**JIRA Ticket**: [ISLANDORA-2446](https://jira.duraspace.org/browse/ISLANDORA-2446)

# What does this Pull Request do?

Fixes a couple potential issues around queuing:
* We are relying on the default Drupal behavior of returning a "reliable" queue class, but other code could change this
* The `hook_cron_queue_info` is not respecting the "cron method" configuration (whether to use drush or drupal cron). This hook could potentially process items in the queue even if we've set the configuration to use "drush".

# What's new?
* Explicitly pass `reliable = TRUE` to `DrupalQueue::get()` to ensure we always get reliable queues
* Add `skip on cron` to `hook_cron_queue_info` implementation


# How should this be tested?
### Setup
- Pull in the changes in the PR
- In `islandora_checksum_checker.module` add the following logging code after line 14 (the `DrupalQueue::get()` call) for testing purposes:
```
watchdog(
  'islandora_checksum_checker',
  'Default queue: ' . variable_get('queue_default_class')
);
watchdog(
  'islandora_checksum_checker',
  'This queue class: ' . get_class($queue)
);
watchdog(
  'islandora_checksum_checker',
  'Is reliable? ' . $queue instanceof DrupalReliableQueueInterface
);
```
- In `islandora_checksum_checker.drush.inc` add the following logging code after line 105:
```
drush_log('Default queue: ' . variable_get('queue_default_class'));
drush_log('This queue class: ' . get_class($queue));
drush_log('Is reliable? ' . $queue instanceof DrupalReliableQueueInterface);
```

### Testing with reliable default queue class
- NOTE: the default Drupal queue class is `SystemQueue`, which is reliable.
- In the checksum_checker configuration, (`/admin/islandora/tools/checksum_checker`), set the "Cron method" to "drush script".
- Run the drupal cron (the "Run cron button" at /admin/config/system/cron)
- Check watchdog logs to ensure that the checksum checker did not run (i.e. no log messages from 'islandora_checksum_checker')
- Run `drush run-islandora-checksum-queue -v` to process the checksum queue via drush
- Check the drush output for the 3 added log messages:
	- "Default queue" should be "SystemQueue" on a fresh drupal install
	- "This queue class" should be "SystemQueue"
	- "Is reliable" should be 1 (TRUE)
- In the checksum configuration, set the "Cron method" to "Drupal cron"
- Run the drupal cron at /admin/config/system/cron
- Check watchdog log output for the 3 added log messages:
	- "Default queue" should be "SystemQueue" on a fresh drupal install
	- "This queue class" should be "SystemQueue"
	- "Is reliable" should be 1 (TRUE)

### Testing with non-reliable default queue
- In your `settings.php`, add the following line to change the default queue class:
`$conf['queue_default_class'] = 'MemoryQueue'`
- Clear the Drupal cache
- Repeat the steps above for "TESTING WITH DEFAULT QUEUE CLASS". The logging output should be:
	- "Default queue: MemoryQueue"
	- "This queue class: SystemQueue"
	- "Is reliable? 1"

# Interested parties
@qadan @Islandora/7-x-1-x-committers 