### PR TITLE
Add php-7.2 and php-7.3 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,22 @@ matrix:
     - php: 5.3.3
       dist: precise
       env: FEDORA_VERSION="3.8.1"
+    - php: 7.2
+      env: FEDORA_VERSION="3.5"
+    - php: 7.2
+      env: FEDORA_VERSION="3.6.2"
+    - php: 7.2
+      env: FEDORA_VERSION="3.7.0"
+    - php: 7.2
+      env: FEDORA_VERSION="3.8.1"
+    - php: 7.3
+      env: FEDORA_VERSION="3.5"
+    - php: 7.3
+      env: FEDORA_VERSION="3.6.2"
+    - php: 7.3
+      env: FEDORA_VERSION="3.7.0"
+    - php: 7.3
+      env: FEDORA_VERSION="3.8.1"
   allow_failures:
     - php: 5.3.3
       dist: precise
@@ -29,6 +45,22 @@ matrix:
       env: FEDORA_VERSION="3.7.0"
     - php: 5.3.3
       dist: precise
+      env: FEDORA_VERSION="3.8.1"
+    - php: 7.2
+      env: FEDORA_VERSION="3.5"
+    - php: 7.2
+      env: FEDORA_VERSION="3.6.2"
+    - php: 7.2
+      env: FEDORA_VERSION="3.7.0"
+    - php: 7.2
+      env: FEDORA_VERSION="3.8.1"
+    - php: 7.3
+      env: FEDORA_VERSION="3.5"
+    - php: 7.3
+      env: FEDORA_VERSION="3.6.2"
+    - php: 7.3
+      env: FEDORA_VERSION="3.7.0"
+    - php: 7.3
       env: FEDORA_VERSION="3.8.1"
 php:
   - 5.4


### PR DESCRIPTION
# What does this Pull Request do?

- Add the `php-7.2` and `php-7.3` version tests during Travis CI build because they're stable versions.

# What's new?
- Add `php-7.2` and `php-7.3` version tests during Travis CI build.