### PR TITLE
Add Solr backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This module requires the following modules/libraries:
 * [Islandora](https://github.com/islandora/islandora)
 * [Tuque](https://github.com/islandora/tuque)
 * [Islandora Checksum](https://github.com/islandora/islandora_checksum) (Optional)
+* [Islandora Solr](https://github.com/islandora/islandora_solr_search) (Optional)
 
 This module is only useful if you use Fedora Commons to generate checksums on datastreams. The easiest way to have Fedora Commons generate checksums is to install and enable the Islandora Checksum module.
 
@@ -26,7 +27,7 @@ Install as usual, see [this](https://drupal.org/documentation/install/modules-th
 
 Set the cron method, number of objects to check per cron run, datastram to check, who to sent report to in Administration » Islandora » Islandora Utility Modules » Checksum checker (admin/islandora/tools/checksum_checker).
 
-![Configuration](https://camo.githubusercontent.com/c5e3d71e0ade7b3da4628d662017c5b6774e9ea8/687474703a2f2f692e696d6775722e636f6d2f7359366f7634412e706e67)
+![Configuration](https://user-images.githubusercontent.com/2857697/64626515-8d9d1700-d3b3-11e9-9859-eb68417b57e8.png)
 
 The two most common options for scheduling the verification are:
 
@@ -43,6 +44,17 @@ The drush command you need to run is `drush run-islandora-checksum-queue`. You s
 ```
   0 * * * * /usr/bin/drush --root=/path/to/drupal --user=fedoraAdmin run-islandora-checksum-queue
 ```
+
+### Solr backend
+
+By default the checksum checker creates a list of all PIDs that don't have the `islandora:collectionCModel` from your Resource Index (Triplestore).
+
+You can use Solr (if you have Islandora Solr installed/enabled) by choosing the "Use Solr for finding objects" option. 
+
+Checking this option will reveal two additional text fields to enter the names of fields which hold:
+1. A created date for the object (this **must** be a non-multi-valued field)
+1. A content model for the object.
+
 
 ### Frequency of verification
 

--- a/islandora_checksum_checker.install
+++ b/islandora_checksum_checker.install
@@ -22,6 +22,9 @@ function islandora_checksum_checker_uninstall() {
     'islandora_checksum_checker_email_reports_to',
     'islandora_checksum_checker_send_complete_message',
     'islandora_checksum_checker_log_mismatches',
+    'islandora_checksum_checker_use_solr',
+    'islandora_checksum_checker_solr_created',
+    'islandora_checksum_checker_solr_model',
   );
   array_walk($variables, 'variable_del');
 }

--- a/islandora_checksum_checker.module
+++ b/islandora_checksum_checker.module
@@ -135,7 +135,7 @@ function islandora_checksum_checker_admin_settings() {
     '#type' => 'container',
     '#states' => array(
       'visible' => array(
-        ':input[name="islandora_checksum_checker_use_solr"]' => array('checked' => true),
+        ':input[name="islandora_checksum_checker_use_solr"]' => array('checked' => TRUE),
       ),
     ),
     'islandora_checksum_checker_solr_created' => array(

--- a/islandora_checksum_checker.module
+++ b/islandora_checksum_checker.module
@@ -483,7 +483,14 @@ EOQ;
  *   An array of PIDs.
  */
 function islandora_checksum_checker_get_objects_solr($limit) {
+  global $user;
   module_load_include('inc', 'islandora_solr', 'includes/utilities.inc');
+
+  // Need to switch to admin to get all objects.
+  $original_user = $user;
+  $old_state = drupal_save_session();
+  drupal_save_session(FALSE);
+  $user = user_load(1);
 
   $offset = variable_get('islandora_checksum_checker_last_item_checked', '0');
 
@@ -505,6 +512,7 @@ function islandora_checksum_checker_get_objects_solr($limit) {
       '!model_field' => $model_field,
     )
   );
+
   $solr_build->buildQuery($solr_query, $params);
   $solr_build->solrParams = islandora_solr_remove_base_filters($solr_build->solrParams);
   $solr_build->solrLimit = $limit;
@@ -516,6 +524,9 @@ function islandora_checksum_checker_get_objects_solr($limit) {
   else {
     $results = array();
   }
+  // Switch back to user
+  $user = $original_user;
+  drupal_save_session($old_state);
 
   $objects_to_check = array_map(function($o) {
     return $o['PID'];

--- a/islandora_checksum_checker.module
+++ b/islandora_checksum_checker.module
@@ -141,7 +141,7 @@ function islandora_checksum_checker_admin_settings() {
     'islandora_checksum_checker_solr_created' => array(
       '#type' => 'textfield',
       '#title' => t('Solr created date field'),
-      '#description' => t("Solr field containing your object's creation date. Defaults to fgs_createdDate_dt"),
+      '#description' => t("Solr field containing your object's creation date. This must be a single valued field so we can sort on it. Defaults to fgs_createdDate_dt"),
       '#default_value' => variable_get('islandora_checksum_checker_solr_created', 'fgs_createdDate_dt'),
       '#autocomplete_path' => 'islandora_solr/autocomplete_luke',
     ),
@@ -166,6 +166,14 @@ function islandora_checksum_checker_admin_settings_validate(array $form, array &
     if (!isset($form_state['values']['islandora_checksum_checker_solr_created']) ||
       empty($form_state['values']['islandora_checksum_checker_solr_created'])) {
       form_set_error('islandora_checksum_checker_solr_created', t('Must provide a date created Solr field.'));
+    }
+    else {
+      module_load_include('inc', 'islandora_solr', 'includes/luke');
+      $info = islandora_solr_get_field_schema($form_state['values']['islandora_checksum_checker_solr_created']);
+      if (isset($info['multivalued']) && $info['multivalued'] === True) {
+        form_set_error('islandora_checksum_checker_solr_created',
+          t('Created date field needs to be non-multi-valued field to allow sorting.'));
+      }
     }
     if (!isset($form_state['values']['islandora_checksum_checker_solr_model']) ||
       empty($form_state['values']['islandora_checksum_checker_solr_model'])) {
@@ -490,6 +498,7 @@ function islandora_checksum_checker_get_objects_solr($limit) {
     'fl' => "PID,{$created_field}",
     'rows' => $limit,
     'start' => $offset,
+    'sort' => "{$created_field}+ASC",
   );
   $solr_query = format_string("-!model_field:(\"info:fedora/islandora:collectionCModel\" OR \"islandora:collectionCModel\")",
     array(

--- a/islandora_checksum_checker.module
+++ b/islandora_checksum_checker.module
@@ -498,7 +498,7 @@ function islandora_checksum_checker_get_objects_solr($limit) {
     'fl' => "PID,{$created_field}",
     'rows' => $limit,
     'start' => $offset,
-    'sort' => "{$created_field}+ASC",
+    'sort' => "{$created_field} ASC",
   );
   $solr_query = format_string("-!model_field:(\"info:fedora/islandora:collectionCModel\" OR \"islandora:collectionCModel\")",
     array(
@@ -507,6 +507,8 @@ function islandora_checksum_checker_get_objects_solr($limit) {
   );
   $solr_build->buildQuery($solr_query, $params);
   $solr_build->solrParams = islandora_solr_remove_base_filters($solr_build->solrParams);
+  $solr_build->solrLimit = $limit;
+  $solr_build->solrStart = $offset;
   $solr_build->executeQuery(FALSE);
   if (isset($solr_build->islandoraSolrResult['response']['objects'])) {
     $results = $solr_build->islandoraSolrResult['response']['objects'];

--- a/islandora_checksum_checker.module
+++ b/islandora_checksum_checker.module
@@ -120,8 +120,58 @@ function islandora_checksum_checker_admin_settings() {
       report to', above. Check this option if you also want mismatches to be logged
       (which is advisable in case the email messages fail to get sent)."),
   );
+  $form['islandora_checksum_checker_use_solr'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Use Solr for finding objects'),
+    '#disabled' => (!module_exists('islandora_solr')),
+    '#default_value' => (module_exists('islandora_solr') ?
+      variable_get('islandora_checksum_checker_use_solr', FALSE) :
+      FALSE),
+    '#description' => t('Checksum checker uses your resource index to locate all the 
+      non-collection objects to run against. Checking this option allows you to
+      use Solr instead. Requires Islandora Solr module.'),
+  );
+  $form['checksum_solr_field'] = array(
+    '#type' => 'container',
+    '#states' => array(
+      'visible' => array(
+        ':input[name="islandora_checksum_checker_use_solr"]' => array('checked' => true),
+      ),
+    ),
+    'islandora_checksum_checker_solr_created' => array(
+      '#type' => 'textfield',
+      '#title' => t('Solr created date field'),
+      '#description' => t("Solr field containing your object's creation date. Defaults to fgs_createdDate_dt"),
+      '#default_value' => variable_get('islandora_checksum_checker_solr_created', 'fgs_createdDate_dt'),
+      '#autocomplete_path' => 'islandora_solr/autocomplete_luke',
+    ),
+    'islandora_checksum_checker_solr_model' => array(
+      '#type' => 'textfield',
+      '#title' => t('Solr content model field'),
+      '#description' => t("Solr field containing your object's content model. Defaults to RELS_EXT_hasModel_uri_ms"),
+      '#default_value' => variable_get('islandora_checksum_checker_solr_model', 'RELS_EXT_hasModel_uri_ms'),
+      '#autocomplete_path' => 'islandora_solr/autocomplete_luke',
+    ),
+  );
 
   return system_settings_form($form);
+}
+
+/**
+ * Implements hook_form_validate
+ */
+function islandora_checksum_checker_admin_settings_validate(array $form, array &$form_state) {
+  if (isset($form_state['values']['islandora_checksum_checker_use_solr']) &&
+    (bool) $form_state['values']['islandora_checksum_checker_use_solr']) {
+    if (!isset($form_state['values']['islandora_checksum_checker_solr_created']) ||
+      empty($form_state['values']['islandora_checksum_checker_solr_created'])) {
+      form_set_error('islandora_checksum_checker_solr_created', t('Must provide a date created Solr field.'));
+    }
+    if (!isset($form_state['values']['islandora_checksum_checker_solr_model']) ||
+      empty($form_state['values']['islandora_checksum_checker_solr_model'])) {
+      form_set_error('islandora_checksum_checker_solr_model', t('Must provide a content model Solr field.'));
+    }
+  }
 }
 
 /**
@@ -319,6 +369,26 @@ function islandora_checksum_checker_validate_checksum($pid) {
 }
 
 /**
+ * Gets PIDs of all objects that are not collection objects. Uses the
+ * system variable 'islandora_checksum_checker_last_item_checked' to page
+ * through all the objects in the repo.
+ *
+ * @param int $limit
+ *   The number of items to add to the queue.
+ *
+ * @return array
+ *   An array of PIDs.
+ */
+function islandora_checksum_checker_get_objects($limit) {
+  if (module_exists('islandora_solr') && variable_get('islandora_checksum_checker_use_solr', FALSE)) {
+    return islandora_checksum_checker_get_objects_solr($limit);
+  }
+  else {
+    return islandora_checksum_checker_get_objects_ri($limit);
+  }
+}
+
+/**
  * Query the RI index.
  *
  * Gets PIDs of all objects that are not collection objects. Uses the
@@ -331,7 +401,7 @@ function islandora_checksum_checker_validate_checksum($pid) {
  * @return array
  *   An array of PIDs.
  */
-function islandora_checksum_checker_get_objects($limit) {
+function islandora_checksum_checker_get_objects_ri($limit) {
   $offset = variable_get('islandora_checksum_checker_last_item_checked', '0');
   // We need to add 1 to the offset so we can use it in the RI query, except
   // the first time this function is invoked
@@ -392,7 +462,75 @@ EOQ;
 }
 
 /**
- * Query the RI index for a count.
+ * Query the Solr index.
+ *
+ * Gets PIDs of all objects that are not collection objects. Uses the
+ * system variable 'islandora_checksum_checker_last_item_checked' to page
+ * through all the objects in the repo.
+ *
+ * @param int $limit
+ *   The number of items to add to the queue.
+ *
+ * @return array
+ *   An array of PIDs.
+ */
+function islandora_checksum_checker_get_objects_solr($limit) {
+  module_load_include('inc', 'islandora_solr', 'includes/utilities.inc');
+
+  $offset = variable_get('islandora_checksum_checker_last_item_checked', '0');
+
+  $created_field = variable_get('islandora_checksum_checker_solr_created', 'fgs_createdDate_dt');
+  $model_field = variable_get('islandora_checksum_checker_solr_model', 'RELS_EXT_hasModel_uri_ms');
+
+  // Query the rindex to get all the objects that have a 'isMemberOfCollection'
+  // relationship but that do not have a 'islandora:collectionCModel' content
+  // model. Sort oldest to newest.
+  $solr_build = new IslandoraSolrQueryProcessor();
+  $params = array(
+    'fl' => "PID,{$created_field}",
+    'rows' => $limit,
+    'start' => $offset,
+  );
+  $solr_query = format_string("-!model_field:(\"info:fedora/islandora:collectionCModel\" OR \"islandora:collectionCModel\")",
+    array(
+      '!model_field' => $model_field,
+    )
+  );
+  $solr_build->buildQuery($solr_query, $params);
+  $solr_build->solrParams = islandora_solr_remove_base_filters($solr_build->solrParams);
+  $solr_build->executeQuery(FALSE);
+  if (isset($solr_build->islandoraSolrResult['response']['objects'])) {
+    $results = $solr_build->islandoraSolrResult['response']['objects'];
+  }
+  else {
+    $results = array();
+  }
+
+  $objects_to_check = array_map(function($o) {
+    return $o['PID'];
+  }, $results);
+
+  // If the number of results returned is fewer than $limit, assume
+  // that we have gotten all objects from the rindex and reset
+  // $offset to 0.
+  if (count($results) < $limit) {
+    $offset = 0;
+    if (variable_get('islandora_checksum_checker_send_complete_message', 0)) {
+      islandora_checksum_checker_send_check_complete_message();
+      variable_set('islandora_checksum_checker_mismatches', array());
+    }
+  }
+  else {
+    $offset = (int) $offset + (int) $limit;
+  }
+  // Update the offset for use in next cron run.
+  variable_set('islandora_checksum_checker_last_item_checked', $offset);
+
+  return $objects_to_check;
+}
+
+/**
+ * Query for a count.
  *
  * Gets the number of items that the checksum checker will run against.
  *
@@ -400,6 +538,23 @@ EOQ;
  *   Count of pids.
  */
 function islandora_checksum_checker_get_number_objects() {
+  if (module_exists('islandora_solr') && variable_get('islandora_checksum_checker_use_solr', FALSE)) {
+    return islandora_checksum_checker_get_number_objects_solr();
+  }
+  else {
+    return islandora_checksum_checker_get_number_objects_ri();
+  }
+}
+
+/**
+ * Query the RI index for a count.
+ *
+ * Gets the number of items that the checksum checker will run against.
+ *
+ * @return int
+ *   Count of pids.
+ */
+function islandora_checksum_checker_get_number_objects_ri() {
   $user = user_load(1);
   drupal_static_reset('islandora_get_tuque_connection');
   $tuque = islandora_get_tuque_connection($user);
@@ -420,6 +575,47 @@ WHERE {
 }
 EOQ;
   return $tuque->repository->ri->countQuery($ri_query, 'sparql');
+}
+
+/**
+ * Query the Solr index for a count.
+ *
+ * Gets the number of items that the checksum checker will run against.
+ *
+ * @return int
+ *   Count of pids.
+ */
+function islandora_checksum_checker_get_number_objects_solr() {
+  module_load_include('inc', 'islandora_solr', 'includes/utilities.inc');
+
+  $created_field = variable_get('islandora_checksum_checker_solr_created', 'fgs_createdDate_dt');
+  $model_field = variable_get('islandora_checksum_checker_solr_model', 'RELS_EXT_hasModel_uri_ms');
+
+  // Query the rindex to get all the objects that have a 'isMemberOfCollection'
+  // relationship but that do not have a 'islandora:collectionCModel' content
+  // model. Sort oldest to newest.
+  $solr_build = new IslandoraSolrQueryProcessor();
+  $params = array(
+    'fl' => "PID,{$created_field}",
+    'rows' => 0,
+  );
+  $solr_query = format_string("-!model_field:(\"info:fedora/islandora:collectionCModel\" OR \"islandora:collectionCModel\")",
+    array(
+      '!model_field' => $model_field,
+    )
+  );
+  $solr_build->buildQuery($solr_query, $params);
+  $solr_build->solrParams = islandora_solr_remove_base_filters($solr_build->solrParams);
+  $solr_build->executeQuery(FALSE);
+  if (isset($solr_build->islandoraSolrResult['response']['numFound'])) {
+    $num_found = $solr_build->islandoraSolrResult['response']['numFound'];
+  }
+  else {
+    watchdog('islandora_checksum_checker', 'Did not find numFound value for Solr query.', WATCHDOG_NOTICE);
+    $num_found = 0;
+  }
+
+  return $num_found;
 }
 
 /**

--- a/islandora_checksum_checker.module
+++ b/islandora_checksum_checker.module
@@ -170,7 +170,7 @@ function islandora_checksum_checker_admin_settings_validate(array $form, array &
     else {
       module_load_include('inc', 'islandora_solr', 'includes/luke');
       $info = islandora_solr_get_field_schema($form_state['values']['islandora_checksum_checker_solr_created']);
-      if (isset($info['multivalued']) && $info['multivalued'] === True) {
+      if (isset($info['multivalued']) && $info['multivalued'] === TRUE) {
         form_set_error('islandora_checksum_checker_solr_created',
           t('Created date field needs to be non-multi-valued field to allow sorting.'));
       }

--- a/islandora_checksum_checker.module
+++ b/islandora_checksum_checker.module
@@ -517,6 +517,14 @@ function islandora_checksum_checker_get_objects_solr($limit) {
   $solr_build->solrParams = islandora_solr_remove_base_filters($solr_build->solrParams);
   $solr_build->solrLimit = $limit;
   $solr_build->solrStart = $offset;
+  if (module_exists('islandora_compound_object')) {
+    // Remove compound part limitations. We remove all these individual filters
+    // to maintain namespace restrictions.
+    $compound_fq = array();
+    $compound_fq[] = variable_get('islandora_compound_object_solr_fq', '-RELS_EXT_isConstituentOf_uri_mt:[* TO *]');
+    $solr_build->solrParams['fq'] = array_diff($solr_build->solrParams['fq'], $compound_fq);
+  }
+
   $solr_build->executeQuery(FALSE);
   if (isset($solr_build->islandoraSolrResult['response']['objects'])) {
     $results = $solr_build->islandoraSolrResult['response']['objects'];


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2472

Requires new Solr function in https://github.com/Islandora/islandora_solr_search/pull/368

# What does this Pull Request do?

Adds option to use your Solr index to get the list of PIDs to run the checksum checker against.

# What's new?

New checkbox on the Admin form which exposes two fields to select the created date and content model solr fields.

If the Islandora Solr module is **not** installed then this option is disabled.

If you select this option, the field you select for your created date **MUST** be single valued so we can sort on it. This is checked via the new function in the related PR in Islandora Solr.

Otherwise we fallback to the Resource index as normal.

# How should this be tested?

Try enabling this option for Islandora Checksum Checker.
Try selecting a field you know to be multi valued (ie. one ending in *_ms or *_mt for dynamic fields) and ensure you can't save the settings.
Try disabling your Islandora Solr and ensure the option is disabled.
Try running the checksum checker cron and drush script and see that they do the same action.

# Additional Notes:

* Does this change the interface, add a new feature, or otherwise change behaviours that would require updating documentation? yes, included
* Does this change add any new dependencies? soft-dependency on Solr
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@Islandora/7-x-1-x-committers
