### PR TITLE
Add the ability to skip audit log update

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Checksum Checker provides two optional drush options that will calculate the num
 Using these two values, and the number of objects in your repository (which you do not need to provide), Checksum Checker will calculate the number of objects to check each cron run.
 
 ### Disable Checksum Checker from triggering an Audit log update
-__WARNING__: This is probably not something you want to change. That's why it isn't in the admin configuration page. Disabling this will prevent fixity checking events from being added to the audit log of each object. Islandora PREMIS wil not long see fixity events because they will no longer be updating the audit log.
+__WARNING__: This is probably not something you want to change. That's why it isn't in the admin configuration page. Disabling this will prevent fixity checking events from being added to the audit log of each object. Islandora PREMIS will no longer see fixity events because echecksum checker will no longer be updating the audit log every time it checks the checksum.
 ```shell
 # Disable Audit Log update when checksum checker touches an object
 $ drush vset islandora_checksum_checker_disable_audit_log_update 1

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Checksum Checker provides two optional drush options that will calculate the num
 Using these two values, and the number of objects in your repository (which you do not need to provide), Checksum Checker will calculate the number of objects to check each cron run.
 
 ### Disable Checksum Checker from triggering an Audit log update
-__WARNING__: This is probably not something you want to change. That's why it isn't in the admin configuration page. Disabling this will prevent fixity checking events from being added to the audit log of each object. Islandora PREMIS will no longer see fixity events because echecksum checker will no longer be updating the audit log every time it checks the checksum.
+__WARNING__: This is probably not something you want to change. That's why it isn't in the admin configuration page. Disabling this will prevent fixity checking events from being added to the audit log of each object. Islandora PREMIS will no longer see fixity events because checksum checker will no longer be updating the audit log every time it checks the checksum.
 ```shell
 # Disable Audit Log update when checksum checker touches an object
 $ drush vset islandora_checksum_checker_disable_audit_log_update 1

--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ Checksum Checker provides two optional drush options that will calculate the num
 
 Using these two values, and the number of objects in your repository (which you do not need to provide), Checksum Checker will calculate the number of objects to check each cron run.
 
+### Disable Checksum Checker from triggering an Audit log update
+__WARNING__: This is probably not something you want to change. That's why it isn't in the admin configuration page.
+```shell
+# Disable Audit Log update when checksum checker touches an object
+$ drush vset islandora_checksum_checker_disable_audit_log_update 1
+
+# Re-enable Audit Log update when checksum checker touches an object
+$ drush vdel islandora_checksum_checker_disable_audit_log_update
+```
+
 ## Documentation
 
 Further documentation for this module is available at [our wiki](https://wiki.duraspace.org/display/ISLANDORA/Islandora+Checksum+Checker).

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Checksum Checker provides two optional drush options that will calculate the num
 Using these two values, and the number of objects in your repository (which you do not need to provide), Checksum Checker will calculate the number of objects to check each cron run.
 
 ### Disable Checksum Checker from triggering an Audit log update
-__WARNING__: This is probably not something you want to change. That's why it isn't in the admin configuration page.
+__WARNING__: This is probably not something you want to change. That's why it isn't in the admin configuration page. Disabling this will prevent fixity checking events from being added to the audit log of each object. Islandora PREMIS wil not long see fixity events because they will no longer be updating the audit log.
 ```shell
 # Disable Audit Log update when checksum checker touches an object
 $ drush vset islandora_checksum_checker_disable_audit_log_update 1

--- a/islandora_checksum_checker.module
+++ b/islandora_checksum_checker.module
@@ -294,7 +294,9 @@ function islandora_checksum_checker_validate_checksum($pid) {
         );
         $log_message = array('logMessage' => trim($fixity_event_message));
         try {
-          $tuque->api->m->modifyObject($pid, $log_message);
+          if (!variable_get('islandora_checksum_checker_disable_audit_log_update', FALSE)) {
+            $tuque->api->m->modifyObject($pid, $log_message);
+          }
         }
         catch (RepositoryException $e) {
           watchdog('islandora_checksum_checker', 'Unable to add fixity event message for !object, !ds_id: !message',


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/ISLANDORA-2497

# What does this Pull Request do?
Turns off the modify trigger when a variable is set so that the audit log isn't triggered upon a checksum check.  

# What's new?
Looks for a variable "**islandora_checksum_checker_disable_audit_log_update**" to determine if it needs to skip the audit log trigger.

# How should this be tested?
1. Ingest a test object.
1. Run checksum checker 
1. review the audit log
1. go to drupal directory and run `$ drush vset islandora_checksum_checker_disable_audit_log_update 1`
1. Do steps #2 & #3 again to see if it had skipped the audit file update.

Verify the steps are written correctly and clearly in the README file.

# Additional Notes:
N/A

# Interested parties
@Islandora/7-x-1-x-committers